### PR TITLE
Increase minimum version of cmake to 3.9 and enable lto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
 project(youtubedl-gui LANGUAGES CXX)
 
@@ -12,11 +12,18 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 INCLUDE(GNUInstallDirs)
+INCLUDE(CheckIPOSupported)
 
 #Set default prefix to /usr
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "/usr")
 endif()
+# check if compiler supports link time optmizations and enable it
+check_ipo_supported(RESULT result)
+if(result)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
+
 
 # uninstall target
 if(NOT TARGET uninstall)


### PR DESCRIPTION
since cmake 3.9 there has been an option to build with link time optimizations(lto) on compilers that support this feature(gcc,clang etc). LTO produces smaller, faster and more debugging friendly binaries. Ubuntu 21.04 enables LTO by default and arch will be implementing this soon.

note: this may cause issues when using clang as a compiler. https://bugreports.qt.io/browse/QTBUG-61710 