### PR TITLE
disable LTO is compiler is not g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,11 @@ endif()
 # check if compiler supports link time optmizations and enable it
 if(LINUX)
   check_ipo_supported(RESULT result)
-  if(result)
-      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-  endif()
+    if (CMAKE_COMPILER_IS_GNUCXX) # clang lto with qt is broken.
+            if(result)
+            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        endif()
+    endif()
 endif()
 
 


### PR DESCRIPTION
it is in testing broken on everything not gnu g++ hence we can disable it for every other compiler keeping working builds even with clang