### PR TITLE
Migrate from youtube-dl to yt-dlp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 project(youtubedl-gui LANGUAGES CXX)
 
@@ -41,7 +41,8 @@ if(NOT TARGET uninstall)
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 endif()
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+find_package(QT NAMES Qt6 COMPONENTS Widgets REQUIRED)
+message(STATUS "Building using Qt version: ${QT_VERSION}")
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 
 set(SRC

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For a system based on Ubuntu 18.04 Bionic Beaver, 20.04 Focal Fossa or 21.04 Hir
 Then, you have to install the latest ```yt-dlp``` version using pip. Do the following:<br/>
 ```sudo pip3 install yt-dlp```
 ### Debian
-For a system running Debian 12 Bookworm (Testing as of now) or later, the application is in the distribution's standard repositories.<br/>
+For a system running Debian 12 Bookworm or later, the application is in the distribution's standard repositories.<br/>
 Simply run ```sudo apt install youtubedl-gui``` to install the GUI interface.<br/><br/>
 Then, make sure ```ffmpeg``` and ```python3-pip``` are on your system too.<br/>
 Finally, execute ```sudo pip3 install yt-dlp``` to get the latest version of ```yt-dlp``` on your system.
@@ -38,13 +38,13 @@ The application will scale automatically with the scaling factor chosen by the d
 
 ## Build From Source
 ### Dependencies
-To build this application from source, you need the basic development tools for the Qt5 framework, and a recent version of the ```youtube-dl``` binary for the application to compile and run on your system.<br/><br/>
+To build this application from source, you need the basic development tools for the Qt5 framework, and a recent version of the ```yt-dlp``` binary for the application to compile and run on your system.<br/><br/>
 Here is a list of build and runtime dependencies for arch linux:<br/>
 ```base-devel qt5-base ffmpeg yt-dlp```<br/>
 
 For debian-based systems (including ubuntu) here is a list of dependencies:<br/>
 ```build-essential cmake qtbase5-dev ffmpeg yt-dlp```<br/><br/>
-Since the version of ```yt-dlp``` is often not current on debian and ubuntu distros, I recommend you install it through ```pip3```(or from backports).
+Since the version of ```yt-dlp``` is often not current on debian and ubuntu distros, I recommend you install it through ```pip3``` (or from backports for Debian).
 
 ### Installing
 To install after having installed the correct dependencies:<br/><br/>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # youtubedl-gui
-A simple-to-use, cross-platform graphical interface for youtube-dl.<br/><br/>
+A simple-to-use, cross-platform graphical interface for yt-dlp.<br/><br/>
 ![youtubedl-gui-screenshot.png](https://github.com/JaGoLi/ytdl-gui/raw/master/resources/youtubedl-gui-screenshot-3.0.png)<br/>
 
 
@@ -16,13 +16,13 @@ To try out the beta branch of this project, you can download the package ```yout
 For a system based on Ubuntu 18.04 Bionic Beaver, 20.04 Focal Fossa or 21.04 Hirsute Hippo, simply add my ppa and install the application:<br/>
 ```sudo add-apt-repository ppa:mordec13/youtubedl-gui```<br/>
 ```sudo apt update && sudo apt install youtubedl-gui```<br/><br/>
-Then, you have to install the latest ```youtube-dl``` version using pip. Do the following:<br/>
-```sudo pip3 install youtube-dl```
+Then, you have to install the latest ```yt-dlp``` version using pip. Do the following:<br/>
+```sudo pip3 install yt-dlp```
 ### Debian
 For a system running Debian 12 Bookworm (Testing as of now) or later, the application is in the distribution's standard repositories.<br/>
 Simply run ```sudo apt install youtubedl-gui``` to install the GUI interface.<br/><br/>
 Then, make sure ```ffmpeg``` and ```python3-pip``` are on your system too.<br/>
-Finally, execute ```sudo pip3 install youtube-dl``` to get the latest version of ```youtube-dl``` on your system.
+Finally, execute ```sudo pip3 install yt-dlp``` to get the latest version of ```yt-dlp``` on your system.
 ### Flatpak
 It is also possible to install the application via Flatpak if there is no package for your distrubition.<br/>
 However, be aware that I am not responsible for its maintenance and that the install size will be an order of magnitude bigger than simply using a package or building from source.<br/><br/>
@@ -40,11 +40,11 @@ The application will scale automatically with the scaling factor chosen by the d
 ### Dependencies
 To build this application from source, you need the basic development tools for the Qt5 framework, and a recent version of the ```youtube-dl``` binary for the application to compile and run on your system.<br/><br/>
 Here is a list of build and runtime dependencies for arch linux:<br/>
-```base-devel qt5-base ffmpeg youtube-dl```<br/>
+```base-devel qt5-base ffmpeg yt-dlp```<br/>
 
 For debian-based systems (including ubuntu) here is a list of dependencies:<br/>
-```build-essential cmake qtbase5-dev ffmpeg youtube-dl```<br/><br/>
-Since the version of ```youtube-dl``` is often not current on debian and ubuntu distros, I recommend you install it through ```pip3```.
+```build-essential cmake qtbase5-dev ffmpeg yt-dlp```<br/><br/>
+Since the version of ```yt-dlp``` is often not current on debian and ubuntu distros, I recommend you install it through ```pip3```(or from backports).
 
 ### Installing
 To install after having installed the correct dependencies:<br/><br/>

--- a/src/mainactions.cpp
+++ b/src/mainactions.cpp
@@ -27,9 +27,7 @@ mainActions::mainActions(QObject *parent) : QObject(parent)	{
         connect(returnAction, &QShortcut::activated, ui->buttonDownload, &QPushButton::click);
 
         //connect defaults checkbox to blurring out of options
-        connect(ui->defaultsCheck, &QCheckBox::stateChanged, window, &ytdl::changeVisibility);
-
-
+        connect(ui->defaultsCheck, &QCheckBox::checkStateChanged, window, &ytdl::changeVisibility);
         // resume user settings
         if (QFile(window->file_qstr).exists()) {
             readConfig* user_settings = new readConfig(window->file_str);

--- a/src/mainactions.cpp
+++ b/src/mainactions.cpp
@@ -233,11 +233,12 @@ void ytdl::printResult(int result_num) {
 }
 
 void ytdl::downloadAction() {
-    std::string ytdl_prog = "youtube-dl 2> /tmp/ytdl_stderr --no-warnings --all-subs";
+    std::string ytdl_prog = "yt-dlp 2> /tmp/ytdl_stderr --no-warnings --all-subs";
     std::string url_str = quote + QString_to_str(ui->lineURL->text()) + quote;
     std::string directory_str = quote + QString_to_str(ui->lineBrowse->text()) + "/%(title)s.%(ext)s" + quote;
     std::string parse_output = R"(stdbuf -o0 grep -oP '^\[download\].*?\K([0-9]+)')";
     std::string thumbnail;
+    std::string embed_subs;
 
     //Youtube playlist support
     std::string playlist;
@@ -334,6 +335,7 @@ void ytdl::downloadAction() {
                     case 2:
                             video_format = "mp4";
                             audio_format = "m4a";
+                            embed_subs = "--embed-subs ";
                             break;
                     case 3:
                             video_format = "webm";
@@ -364,7 +366,7 @@ void ytdl::downloadAction() {
 
             std::string command = ytdl_prog + whitespace + url_str + " -o " + directory_str \
                     + " -f " + format_options \
-                    + " --ignore-config " + playlist + "--newline | " \
+                    + " --ignore-config " + playlist + embed_subs + "--newline | " \
                     + parse_output;
 
             this->run_ytdl(command);


### PR DESCRIPTION
Debian and Arch Linux have now migrated from youtube-dl to yt-dlp: youtube-dl is no longer in Debian packages and youtube-dl have moved in AUR for Arch Linux.
Youtube-dl last release was on December 16, 2021 while yt-dlp last release was on December 8, 2025.
Debian package of ytdl-gui now use yt-dlp.
I think that upstream ytdl-gui should now migrate to yt-dlp.
It also support a new feature: `--embed-subs` that embed subtitles in mp4 files.
I included this feature in this merge request.